### PR TITLE
Make comfy compatible with ruby 3.0

### DIFF
--- a/lib/comfortable_mexican_sofa/routing.rb
+++ b/lib/comfortable_mexican_sofa/routing.rb
@@ -6,7 +6,7 @@ require_relative "routes/cms"
 class ActionDispatch::Routing::Mapper
 
   def comfy_route(identifier, options = {})
-    send("comfy_route_#{identifier}", options)
+    send("comfy_route_#{identifier}", **options)
   end
 
 end


### PR DESCRIPTION
The library is no longer compatible with Ruby 3.0 due to this [problem](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).
The current PR should make a fix.